### PR TITLE
Version (2.0.1) Transferspeicher zum Upload großer Dokumente zugefügt

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Europace-API rund um hochgeladene Dokumente und freigegebene Unterlagen.
     + [Beispielaufruf](#beispielaufruf)
     + [UML Sequenz-Diagramme](#uml-sequenz-diagramme)
     + [JAVA Client generieren](#java-client-generieren)
+- [Dokument per URL bereitstellen](#dokument-per-url-bereitstellen)
+    + [1. Signed URL erstellen](#1-signed-url-erstellen)
+    + [2. Dokument in Transferspeicher hochladen](#2-dokument-in-transferspeicher-hochladen)
+    + [3. Dokument bereitstellen](#3-dokument-bereitstellen)
 - [Kategorien](#kategorien)
 - [FAQs](#faqs)
 - [Autorisierung](#autorisierung)
@@ -31,7 +35,7 @@ Abrufen der Metadaten zu allen Dokumenten des Vorgangs Z75226:
 ```
 curl --location --request GET 'https://api.europace2.de/v1/dokumente/?vorgangsNummer=Z75226' \
 --header 'Authorization: Bearer jwtToken' 
-``` 
+```
 
 ##### UML Sequenz-Diagramme
 
@@ -53,7 +57,7 @@ java -jar swagger-codegen-cli-3.0.16.jar generate \
 -l java -c codegen-config-file.json -o generated
 ```
 
-Beispiel _codegen-config-file.json_: 
+Beispiel _codegen-config-file.json_:
 
 ```
 {
@@ -63,7 +67,72 @@ Beispiel _codegen-config-file.json_:
   "artifactVersion": "${ARTIFACT_VERSION}",
   "dateLibrary": "java8"
 }
-``` 
+```
+
+### Dokument per URL bereitstellen
+Dokumente können über eine frei zugängliche URL bereitgestellt werden. Eine solche URL kann wie in Schritt 3 gezeigt direkt verwendet werden. Alternativ kann über den Endpunkt
+/dokumente/transferspeicher ein temporärer Speicher erstellt werden, der eine signed URL generiert. Das wird in Schritt 1 und 2 demonstriert.
+
+Die Dokumente müssen PDF- oder Bilddateien sein und eine Maximalgröße von 100 Megabyte nicht überschreiten.
+
+##### 1. Signed URL erstellen
+Anfrage
+```
+curl --location --request POST 'https://api.europace2.de/v1/dokumente/transferspeicher' \
+--header 'Authorization: Bearer jwtToken'
+```
+Antwort
+```
+{
+    "uploadData": {
+        "url": "https://s3.eu-central-1.amazonaws.com/filecachestack-filecache8e64047f-1sk2qs95dbtr1",
+        "fields": {
+            "key": "9a7ac6f2-2666-4d37-97e7-83ed8ba45184",
+            "bucket": "filecachestack-filecache8e64047f-1sk2qs95dbtr1",
+            "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
+            "X-Amz-Credential": "Credential-Token",
+            "X-Amz-Date": "20200221T123511Z",
+            "X-Amz-Security-Token": "Security-Token",
+            "Policy": "eyJleHBpcmF0aW9uIjoiMjAyMC0wMi0yMVQxMzozNToxMVoiLCJjb25kaXRpb25zIjpbWyJjb250Z",
+            "X-Amz-Signature": "90758c081db7d8f3ac92c0c41a8becc308c074291994e6f48ea99321ba93c9ee"
+        }
+    },
+    "downloadUrl": "https://filecachestack-filecache8e64047f-1sk2qs95dbtr1.s3.eu-central-1.amazonaws.com/9a7ac6f2-2666-4d37-97e7-83ed8ba45184?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Credential&X-Amz-Date=20200221T123511Z&X-Amz-Expires=900&X-Amz-Security-Token=Security-Token&X-Amz-SignedHeaders=host"
+}
+```
+Die erstellten Urls zum Hoch- und Runterladen sind 60 Minuten gültig und können mehrfach aufgerufen werden.
+
+##### 2. Dokument in Transferspeicher hochladen
+Anfrage
+```
+curl --location --request POST 'https://s3.eu-central-1.amazonaws.com/filecachestack-filecache8e64047f-1sk2qs95dbtr1' \
+--header 'Content-Type: multipart/form-data; boundary=--------------------------198537869835208851079266' \
+--form 'key=9a7ac6f2-2666-4d37-97e7-83ed8ba45184' \
+--form 'bucket=filecachestack-filecache8e64047f-1sk2qs95dbtr1' \
+--form 'X-Amz-Algorithm=AWS4-HMAC-SHA256' \
+--form 'X-Amz-Credential=Credential-Token' \
+--form 'X-Amz-Date=20200221T123511Z' \
+--form 'X-Amz-Security-Token=Security-Token' \
+--form 'Policy=eyJleHBpcmF0aW9uIjoiMjAyMC0wMi0yMVQxMzozNToxMVoiLCJjb25kaXRpb25zIjpbWyJjb250ZW50LWxlbmd0aC1yYW5nZSIsMCwxMDAwMDAwMDBdLHsia2V5IjoiOWE3YWM2ZjItMjY2Ni00ZDM3LTk3ZTctODNlZDhiYTQ1MTg0In0seyJidWNrZXQiOiJmaWxlY2FjaGVzdGFjay1tdHAtZmlsZWNhY2hlbXRwOGU2NDA0N2YtMXNrMnFzOTVkYnRyMSJ9LHsiWC1BbXotQWxnb3JpdGhtIjoiQVdTNC1ITUFDLVNIQTI1NiJ9LHsiWC1BbXotQ3JlZGVudGlhbCI6IkFTSUFRQkhPSEdOR1pNNUY2Sk43LzIwMjAwMjIxL2V1LWNlbnRyYWwtMS9zMy9hd3M0X3JlcXVlc3QifSx7IlgtQW16LURhdGUiOiIyMDIwMDIyMVQxMjM1MTFaIn0seyJYLUFtei1TZWN1cml0eS1Ub2tlbiI6IklRb0piM0pwWjJsdVgyVmpFR1VhREdWMUxXTmxiblJ5WVd3dE1TSkdNRVFDSUFVb2gwam4xVTl5N0hhY2F2cTRCMEt5YnVudW54dUlPVGJSWjRPaFRCR1ZBaUJYUW5WYkpxSDl4MHZUay93YStydW1FVDgyWTF5d0FMc1A1ME5meXA4RXhpcjlBUWd1RUFBYUREQXdNalkwTnpBM056Y3dPU0lNMFdLKzFrSzlTaDhpa05TV0t0b0JrU3FzTklkY3hjMk5XSTJhVnpBa0RsMTBsL1Q1blFqNXZBbFFwS1ptMEp1UkFyTUJ1UEJtdWFFUE9VclBnSHhXN2tsSUpFcDVsV0JxMG5aVzRhcWYvL3VsSUlselRTazlCYmZNbDVhNXFuNVlvcXQ3WjBsZERWVFE0UGtkMFBWazhQTUxTT0c2WU9jdnNwZGtFU1lLU1JZN0x6d2ZIekxNcUUzaGxzbC9lRCtQK3ZUOE9ISGtSZXZscld1VjlLdWg0ZVpJb3ErOEhZemxBeE50WTRPUUc1Smxkem9nQ2ZxZmYza2lJamFmYWd4NGIwTnlvaWNNcC93VXl0TVFieFpndWJVaTM4V0Q2NHl3ZEhnem9lMHl1d3lUL08vQzRHdzZSM3N3L3B5LzhnVTY0Z0hJOVBNbW5nT1UvdUUwc09SbUkzWHpCSkpYcTc5VGs1UGl4d2pNc05HeENpRnBTZjFDdHMvQUcxTktpQi9HQTFscUREVDZuSHNhQ21HN2IvanJNcDZJb1hGOXEyNjFaSzQ4KzVrQ2x0THArMjZUMHl2d0NqWGthTW9zbWtHM01tVjBadGYxMkZJQmxVQVh2MGp2M3BFNjNtdUk0eTB0RnEvWXIybVFmQmxpaFJMZUZMWXJRU2dGSHVGb2Qvdy9Cdjd2ajdtUldoVWZ0TjBwVHFudWVMT1NPKzY0ZjdtZXhQLzVxSXg0NEhxUlNqYUhLb2J1LzVSajFFOW1HbFdsdjBNZWdlNThtaUlNY1YwMnFlK1FkdG9XVG9oekZEZ1BYaWxiZTFhYk8rN2lLVi91In1dfQ==' \
+--form 'X-Amz-Signature=90758c081db7d8f3ac92c0c41a8becc308c074291994e6f48ea99321ba93c9ee' \
+--form 'file=@/Pfad/zum/Dokument.pdf'
+```
+Bei der Anfrage werden die Daten aus "uploadData" aus Schritt 1 verwendet. Die "url" bildet das Ziel der Anfrage, die Elemente der Liste "fields" Form-Parameter. Als letzter Parameter
+wird unter "file" der Pfad zum hochzuladenden Dokument angegeben.
+
+##### 3. Dokument bereitstellen
+Anfrage
+```
+curl --location --request POST 'https://api.europace2.de/v1/dokumente' \
+--header 'Authorization: Bearer jwtToken' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+	"anzeigename" : "Kontoauszug.jpg",
+	"vorgangsNummer" : "MA9PSX",
+	"url" : "https://filecachestack-filecache8e64047f-1sk2qs95dbtr1.s3.eu-central-1.amazonaws.com/9a7ac6f2-2666-4d37-97e7-83ed8ba45184?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Credential&X-Amz-Date=20200221T123511Z&X-Amz-Expires=900&X-Amz-Security-Token=Security-Token&X-Amz-SignedHeaders=host"
+}'
+```
+Zur Bereitstellung wird die frei zugängliche bzw. die "downloadUrl" aus der Antwort aus Schritt 1 verwendet.
 
 ### Kategorien
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Dokumente API
   description: API rund um Plattformdokumente
-  version: 2.0.0
+  version: 2.0.1
 paths:
   /dokumente:
     post:
@@ -106,6 +106,40 @@ paths:
             - API
       tags:
         - Vorgang
+  /dokumente/transferspeicher:
+    post:
+      summary: Transferspeicher für ein Dokument erstellen
+      description: |
+        Einen Transferspeicher für ein Dokument erstellen, aus dem das Dokument per signed URL (AWS Pre-Signed POST) hochgeladen werden kann. Beipiel siehe Readme.
+      operationId: transferspeicher
+      responses:
+        "201":
+          description: Transferspeicher erfolgreich erstellt
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Transferspeicher"
+          links:
+            /dokumente:
+              operationId: uploadDokument
+              parameters:
+                DokumentUpload:
+                  url: '$response.body#/downloadUrl'
+                  anzeigename: zu setzen
+                  vorgangsnummer: zu setzen
+              description: >
+                Die `downloadUrl` kann als `url` in `POST /dokumente` verwendet werden. Vorher muss das Dokument an die Url unter `UploadData.url` mit `POST` übertragen werden.
+        default:
+          description: Unerwarteter Fehler
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      security:
+        - oauth2:
+            - API
+      tags:
+        - Dokumente
   "/dokumente/{dokumentId}":
     get:
       summary: Metadaten zu einem Dokument laden
@@ -1031,11 +1065,30 @@ components:
           description: Vorgangsnummer, dem das Dokument zugeordnet werden soll.
           type: string
         url:
-          description: Frei zugängliche upload URL
+          description: Frei zugängliche URL zum Dokument. Kann z.B. mit 'POST /dokumente/transferspeicher' erstellt werden.
           type: string
       required:
         - url
         - vorgangsNummer
+    Transferspeicher:
+      type: object
+      properties:
+        uploadData:
+          $ref: "#/components/schemas/UploadData"
+        downloadUrl:
+          description: URL zum Abrufen des Dokuments aus dem Transferspeicher.
+          type: string
+    UploadData:
+      type: object
+      properties:
+        url:
+          description: URL zum Hochladen des Dokuments in den Transferspeicher.
+          type: string
+        fields:
+          description: AWS-Felder
+          type: object
+          additionalProperties:
+            type: string
     AenderbareDokumentMetadaten:
       description: Metadaten die für ein Dokument geändert werden können.
       type: object


### PR DESCRIPTION
beachte bitte:
https://github.com/hypoport/ep-api-community/blob/master/API-RELEASE-CHECKLIST.md

Hier können die To-Dos abgehakt werden:
* [x] Neue Versionsnummer im Commit definiert
* [x] Github Release erzeugt (nach dem Mergen in den Master)
* [x] Postman Collection angepasst (falls zutreffend)
