### PR TITLE
Link zwischen Transferspeicher und Dokumentupload korrigiert

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -121,13 +121,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/Transferspeicher"
           links:
-            /dokumente:
+            UploadWithUrl:
               operationId: uploadDokument
-              parameters:
-                DokumentUpload:
-                  url: '$response.body#/downloadUrl'
-                  anzeigename: zu setzen
-                  vorgangsnummer: zu setzen
+              requestBody:
+                url: '$response.body#/downloadUrl'
               description: >
                 Die `downloadUrl` kann als `url` in `POST /dokumente` verwendet werden. Vorher muss das Dokument an die Url unter `UploadData.url` mit `POST` übertragen werden.
         default:


### PR DESCRIPTION
@gomil @Helge-S 

So sollte der Link jetzt richtig gesetzt sein. Angezeigt wird es in der Swagger Doku leider nicht besonders schön. Das ist aber auch bei deren Beispiel aus den Docs so (vgl. https://swagger.io/docs/specification/links/ )